### PR TITLE
Fixed issue, when refreshing a browser page that contains a breadcrumb trail would results in trail lost.

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -38,6 +38,11 @@ export class BreadcrumbComponent implements OnInit, OnChanges {
             this._urls.unshift(this.prefix);
         }
 
+        if (this.router.navigated) {
+            this._urls.length = 0; //Fastest way to clear out array
+            this.generateBreadcrumbTrail(this.router.routerState.snapshot.url);
+        }
+
         this._routerSubscription = this.router.events.subscribe((navigationEnd:NavigationEnd) => {
 
            if (navigationEnd instanceof NavigationEnd) {


### PR DESCRIPTION
ng5-breadcrumb have same issue as ng2-breadcrumb 
https://github.com/gmostert/ng2-breadcrumb/issues/100

"When refreshing (browser refresh - F5) a page that contains a `breadcrumb` trail, the trail is lost.
If the breadcrumb trail includes a prefix, only the prefix is shown after the refresh."

To fix this, `generateBreadcrumbTrail()` method needs to be called from `ngOnInit()`.